### PR TITLE
Build for version/tag bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,3 +12,12 @@ jobs:
               uses: actions/setup-python@v5
               with:
                 python-version: '3.x'
+            - name: generate_tag
+              run: |
+                NEW_TAG=$(python ./.ci/bump.py 2>&1)
+                echo "Generated new tag: $NEW_TAG"
+                #echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+                git config user.name "GitHub Actions"
+                git config user.email "github-actions@users.noreply.github.com"
+                git tag $NEW_TAG
+                git push origin main

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,5 @@
+# Overview
+This repo is basically a test bed for Github actions, workflows and mechanisms I use in other repositories and projects.
+I do this here because I don't want to risk other project work and it will all be in public repos anyway at some point.
+
+If anything I do here helps others then great :)


### PR DESCRIPTION
Tag bump script. Don't think git origin push will work because of restrictions on the branch. Need to do PR -> AutoMerge -> No CI. Not ideal but a reasonable workflow.

[Ticket: #192]